### PR TITLE
[WIP] odoo-tester: use diff-cover to measure changed code coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN dnf install -y python3-PyPDF2 python3-passlib python3-babel \
 		   python3-jinja2 python3-reportlab python3-html2text \
 		   python3-docutils python3-num2words python3-phonenumbers \
 		   python3-vatnumber python3-xlrd python3-xlwt \
-		   python3-coverage python3-coveralls python3-magic \
+		   python3-coverage python3-coveralls python3-magic python3-diff-cover \
 		   wkhtmltopdf nodejs-less postgresql-server \
 		   findutils unzip libpng15 compat-openssl10 ${H2P_URI} \
 		   texlive-times texlive-courier ; \
@@ -66,6 +66,8 @@ RUN pg_ctl start ; \
 #
 USER root
 RUN mkdir /opt/odoo-addons
+RUN mkdir /opt/odoo-addons/addons
+RUN chown -R odoo /opt/odoo-addons/
 COPY odoo-wrapper /usr/local/bin/odoo-wrapper
 
 # Upstream Odoo snapshot

--- a/odoo-wrapper
+++ b/odoo-wrapper
@@ -10,7 +10,7 @@ command="/opt/odoo/odoo-bin --database odoo --stop-after-init"
 
 # Extend Odoo command to get coverage tests for any (non-core) addons
 #
-addonsdir=/opt/odoo-addons
+addonsdir=/opt/odoo-addons/addons
 addonspath=/opt/odoo/odoo/addons,/opt/odoo/addons
 addons=$(find ${addonsdir} -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 if [ -n "${addons}" ] ; then
@@ -42,7 +42,7 @@ su postgres -c "pg_ctl start"
 
 # Run Odoo
 #
-su odoo -l -c "${command}"
+su odoo -l -c "cd /opt/odoo-addons/; ${command}"
 
 # Stop database
 #
@@ -51,5 +51,5 @@ su postgres -c "pg_ctl stop"
 # Generate coverage report, if applicable
 #
 if [ -n "${addons}" ] ; then
-    su odoo -l -c "coverage3 report --show-missing"
+    su odoo -l -c "cd /opt/odoo-addons/ && coverage3 report --show-missing && coverage3 xml && diff-cover coverage.xml"
 fi


### PR DESCRIPTION
Changes I made to docker files:

*   install the diff-cover package

*   The sub-folders from udes-open are copied to the docker image. However this excludes the .git folder, which is used by diff-cover to determine code changes - solution: copy the parent folder.

*   diff-cover needs coverage data to be collected when the test is run relative to the "root" folder (that contains the .git folder):

*   All the coverage & diff-cover commands needs to be run from the "root" directory - solution: change to the "root" folder before running

*   The coverage commands create files in the "root" directory which require write permissions - solution: update permissions on the root folder to allow coverage data to be written

This is connected to another PR (in udes-open: [github.com/unipartdigital/udes-open/pull/229](https://github.com/unipartdigital/udes-open/pull/229)) with the change:
*   Copy the parent folder changes the location of modules. There is some code to identify modules which are now wrong - solution: update the code to look for modules.



Below is an example of the results of calling "diff-cover coverage.xml":

```
-------------
Diff Coverage
Diff: origin/master...HEAD, staged and unstaged changes
-------------
addons/service_job/models/sale_order.py (0.0%): Missing lines 26,31
addons/service_job/models/servicejob.py (66.7%): Missing lines 982
-------------
Total:   5 lines
Missing: 3 lines
Coverage: 40%
-------------

```
Each file with changes in the diff is listed along with:

* the percentage of the changed lines of code that are executed tests
* a list of the lines of code that are not hit (if the percentage is <100%)

Also there is a summary of changed lines and the number of lines that are executed across all the files in the diff. 